### PR TITLE
Switch output writing to h5py to reduce memory footprint. Update version

### DIFF
--- a/rinokeras/core/v1x/train/RinokerasGraph.py
+++ b/rinokeras/core/v1x/train/RinokerasGraph.py
@@ -160,23 +160,39 @@ class RinokerasGraph(ABC):
                   data_len: Optional[int] = None,
                   epoch_num: Optional[int] = None,
                   summary_writer: Optional[tf.summary.FileWriter] = None,
-                  save_outputs: Optional[str] = None) -> MetricsAccumulator:
+                  save_outputs: Optional[str] = None,
+                  save_format: Optional[str] = 'pkl') -> MetricsAccumulator:
+
+        if save_format == 'pkl':
+            all_outputs = []
+        elif save_format == 'h5':
+            h5_outf = h5py.File(save_outputs, 'w')
+            i = 0
+        else:
+            raise Exception('Unsupported save format: {}'.format(save_format))
 
         with self.add_progress_bar(data_len, epoch_num).initialize():
             assert self.epoch_metrics is not None
-            if save_outputs is not None:
-                i = 0
-                with h5py.File(save_outputs, 'w') as f:
-                    while True:
-                        loss, outputs = self.run('default', return_outputs=True)
-                        grp = f.create_group(str(i))
+            while True:
+                if save_outputs is not None:
+                    loss, outputs = self.run('default', return_outputs=True)
+                    if save_format == 'pkl':
+                        all_outputs.append(outputs)
+                    elif save_format == 'h5':
+                        grp = h5_outf.create_group(str(i))
                         outputs = outputs[0]  # can we rely on this being a tuple of length 1?
                         for key in outputs.keys():
                             grp.create_dataset(key, data=outputs[key])
                         i += 1
-            else:
-                while True:
+                else:
                     self.run('default')
+
+        if save_format == 'h5':
+            h5_outf.close()
+        if save_outputs is not None and save_format == 'pkl':
+            with open(save_outputs, 'wb') as f:
+                pkl.dump(all_outputs, f)
+
         return self.epoch_metrics
 
     def run_for_n_steps(self,


### PR DESCRIPTION
Collecting all data and then pickling can crash a machine with limited memory. 

e.g. a 20GB results set (held in memory) will crash a 32GB machine. This is partially due to the memory overhead of pickling an object. Writing to hdf5 allows us to write iteratively, reducing the memory footprint overall, and avoiding the pickling overhead.